### PR TITLE
Streamlined setup for using RVM/Bundler

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source "https://rubygems.org"
-ruby RUBY_VERSION
+ruby "2.1.5"
 
 # Hello! This is where you manage which Jekyll version is used to run.
 # When you want to use a different version, change it below, save the

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ First, ensure you have a version of Ruby >= 2.1.0 - if you have RVM installed, t
 directory it will attempt to set the Ruby version to that specified in `Gemfile`. After which
 execute:
 
-    $ sudo gem install bundler
+    $ gem install bundler
 
 Next, after cloning the repository go into the working folder and:
 

--- a/README.md
+++ b/README.md
@@ -4,9 +4,15 @@ This is the Jekyll website source for the Tasmanian Linux User Group (TasLUG).
 
 # Usage
 
-First, ensure you have a version of ruby >= 2.1.0. After which execute:
+The follow details how you can work on the site locally without polluting your local Ruby
+environment (similar to Python virtualenvs). It can do this through the use of
+[RVM](https://rvm.io/) and [Bundler](https://bundler.io/).
 
-    $ sudo gem install jekyll bundler
+First, ensure you have a version of Ruby >= 2.1.0 - if you have RVM installed, then on entering the
+directory it will attempt to set the Ruby version to that specified in `Gemfile`. After which
+execute:
+
+    $ sudo gem install bundler
 
 Next, after cloning the repository go into the working folder and:
 

--- a/_config.yml
+++ b/_config.yml
@@ -32,3 +32,4 @@ gems:
 exclude:
   - Gemfile
   - Gemfile.lock
+  - vendor


### PR DESCRIPTION
Now when you `cd` into the directory RVM should set the ruby version, and then you can run `bundler` to get all the dependencies - including jekyll. From there you can now also run with no errors, due to the updates to `_config.yml`.

I set he ruby version based on what it appears that @faulteh is using.