### PR TITLE
GNU Social import script and imported posts

### DIFF
--- a/_posts/2016-08-14-hobart-august-18th-meeting-high-performance-computing-hpc-andrew-elwell.md
+++ b/_posts/2016-08-14-hobart-august-18th-meeting-high-performance-computing-hpc-andrew-elwell.md
@@ -1,0 +1,44 @@
+---
+layout: post
+title: "Hobart August 18th Meeting - High Performance Computing (HPC) - Andrew Elwell"
+date: 2016-08-14 16:55 +1000
+categories: hobart
+---
+
+Hello LUGgers!  
+  
+This month we have Andrew Elwell giving us a talk about High Performance
+Computing. Beat the winter by joining us at Hotel SoHO this Thursday while we
+turn up the megahertz and lower the latency.  
+  
+Andrew will be talking about High Performance Computing (HPC) and covering
+topics such as clustering, systems management, some basic overview of
+performance, what makes HPC so "special" (and expensive) and how HPC differs
+from High Throughput Computing, Cloud and other fashionable technologies.  
+  
+
+## Where
+
+  * Hotel SoHO
+  * 124 Davey Street
+  * Upstairs meeting room (usually, but we might also be sent down the back downstairs)
+
+## When
+
+  * Thursday 18th August 2016
+
+## Agenda
+
+  * 6pm - Arrive, set up talk, grab a drink, order some food.
+  * 6.30pm - Tech support - let the hive mind solve your problems
+  * 7pm - High Performance Computing - Andrew Elwell
+
+## Bio
+
+Andrew has been a system administrator since the 2.0 kernel appeared, working
+in both Academia and Industry. He's worked on various systems including a
+#[9](https://taslug.org.au/tag/9) machine in the top500 (HPCx), the first
+BlueGene/L in Europe. He currently works for the Pawsey Supercomputing Centre
+in WA as a senior system administrator, working with the largest Cray computer
+in the southern hemisphere. Prior to coming to Australia, he worked at CERN
+providing software for the Worldwide Large Hadron Computing Grid (WLCG)

--- a/_posts/2016-08-16-launceston-january-meeting-27th-aug-how-to-make-useful-iot-gadgets-in-launceston.md
+++ b/_posts/2016-08-16-launceston-january-meeting-27th-aug-how-to-make-useful-iot-gadgets-in-launceston.md
@@ -1,0 +1,31 @@
+---
+layout: post
+title: "Launceston January Meeting: 27th Aug - How to make useful IoT gadgets (in Launceston!)"
+date: 2016-08-16 15:29 +1000
+categories: launceston
+---
+
+Hi people! For this month's Launceston meeting, local software/hardware
+developer Mike Cruse be presenting a talk on creating "Internet of Things"
+gadgets. Please note the venue change for this meeting!  
+  
+**Where**  
+Definium Technologies  
+46 Canning Street  
+Launceston  
+  
+**When**  
+Saturday 27th August  
+2:00pm Start  
+People are welcome to arrive from 1:00pm for an early chat/tour.  
+  
+Additional topics to be covered at this meeting:  
+* Sensors and Gateways  
+* What is worth sensing  
+* Where does the data go (SenseT, CSIRO)  
+* Long distance, low power radio communication (LoRa and others)  
+* Hardware/Software design (from an idea to a 1000 gadgets)  
+* Advanced surface mount manufacturing (Overview of the steps in the process, demo)  
+  
+  
+Hope to see you there!

--- a/_posts/2016-09-04-taslug-september-14th-meeting-esp8266-hackfest-redux.md
+++ b/_posts/2016-09-04-taslug-september-14th-meeting-esp8266-hackfest-redux.md
@@ -1,0 +1,37 @@
+---
+layout: post
+title: "TasLUG September 14th Meeting - ESP8266 Hackfest Redux"
+date: 2016-09-04 16:36 +1000
+categories: hobart
+---
+
+Hello LUGgers!  
+  
+Things are starting to get warmer, and so TasLUG is venturing away from our
+usual meetup at the pub and going back to Hobart Hackerspace for their
+Wednesday open night. If you were part of the first ESP8266 Hackfest a few
+months ago you should bring your parts and/or project and we'll take it for
+another spin.  
+  
+A few of us have had some success with their NodeMCU devices. Mark has his
+integrated with the OpenHAB home automation system. Richard tied his directly
+to a 433MHz transmitter, and I connected up an ultrasonic sensor.  
+  
+We'll demo these projects and help everyone else still having issues getting
+their projects going. It will also be a great opportunity to mix with the
+Hackerspace members and find out what's going on at the space.  
+  
+
+### Where
+
+Hobart Hackerspace - 2 St Johns Ave, New Town (NOTE: Not our usual location!)  
+  
+
+### When
+
+WEDNESDAY September 14th, from 6pm (NOTE: not our usual Thursday!)  
+  
+
+### Agenda
+
+6pm onwards - ESP8266 Project Demos and tech support

--- a/_posts/2016-09-16-launceston-september-meeting-24th-sept-creating-a-scene-with-blender-royal-oak.md
+++ b/_posts/2016-09-16-launceston-september-meeting-24th-sept-creating-a-scene-with-blender-royal-oak.md
@@ -1,0 +1,21 @@
+---
+layout: post
+title: "Launceston September Meeting: 24th Sept - Creating A Scene With Blender (Royal Oak)"
+date: 2016-09-16 11:56 +1000
+categories: launceston
+---
+
+Hi people! For this month's Launceston meeting, we'll be taking a look at
+using Blender to create, light and texture an environment and animate a moving
+camera through it.  
+  
+**Where**  
+Upstairs meeting room  
+Royal Oak  
+Crnr Brisbane &amp; Tamar Streets  
+  
+**When**  
+Saturday 24th September  
+2:00pm Start  
+As usual, people are welcome to join for lunch downstairs at 1:00pm  
+Hope to see you there!

--- a/_posts/2016-10-11-hobart-october-19th-meeting-brewing-beer-with-open-source-peter-lawler.md
+++ b/_posts/2016-10-11-hobart-october-19th-meeting-brewing-beer-with-open-source-peter-lawler.md
@@ -1,0 +1,27 @@
+---
+layout: post
+title: "Hobart October 19th Meeting - Brewing Beer with Open Source (Peter Lawler)"
+date: 2016-10-11 11:07 +1100
+categories: hobart
+---
+
+Before October completely runs away from me, let me invite you to this month's
+meeting at the Tasman Quartermaster's Arms (note not our regular meeting
+place!) on Wednesday 19th October. I was going to have it on Thursday but it's
+Show Day and places are closed so I've put it on Wednesday again. However
+being the night before a public holiday means you can have a few more drinks.
+It's also my birthday so you can come along and call me an old bastard.  
+  
+We'll be upstairs at the Quartermaster's Arms for dinner, drinks and a
+discussion by Peter Lawler on his recent attempts at brewing beer and using
+open source to control the brewing process. Come and listen find some great
+ideas and the failures along the way. Peter has been using the Beaglebone
+Black for a while and has been looking at the real time control units on the
+board.  
+  
+Could I please get an idea of numbers attending - please send me an RSVP by
+email.  
+  
+Tasman Quartermaster's Arms is at 134 Elizabeth St Hobart.  
+  
+We'll be there from 6pm.

--- a/_posts/2016-10-16-launceston-september-meeting-29th-oct-dia-as-a-game-development-tool-royal-oak.md
+++ b/_posts/2016-10-16-launceston-september-meeting-29th-oct-dia-as-a-game-development-tool-royal-oak.md
@@ -1,0 +1,21 @@
+---
+layout: post
+title: "Launceston September Meeting: 29th Oct - Dia as a Game Development Tool (Royal Oak)"
+date: 2016-10-16 17:07 +1100
+categories: launceston
+---
+
+Hi people! For this month's Launceston meeting, we'll be taking a look at
+using the F/OSS diagramming tool Dia to assist with planning, designing and
+refining a game concept.  
+  
+**Where**  
+Upstairs meeting room  
+Royal Oak  
+Crnr Brisbane &amp; Tamar Streets  
+  
+**When**  
+Saturday 29th October  
+2:00pm Start  
+As usual, people are welcome to join for lunch downstairs at 1:00pm  
+Hope to see you there!

--- a/_posts/2016-11-22-launceston-september-meeting-26th-november-using-libreoffice-impress-for-fun-amp-presentations-royal-oak.md
+++ b/_posts/2016-11-22-launceston-september-meeting-26th-november-using-libreoffice-impress-for-fun-amp-presentations-royal-oak.md
@@ -1,0 +1,23 @@
+---
+layout: post
+title: "Launceston September Meeting: 26th November - Using LibreOffice Impress For Fun &amp; Presentations (Royal Oak)"
+date: 2016-11-22 12:27 +1100
+categories: launceston
+---
+
+Hi people! Apologies for the late announcement. For this month's Launceston
+meeting, we'll be taking a look at making slideshow presentations with
+LibreOffice Impress.  
+  
+**Where**  
+Upstairs meeting room  
+Royal Oak  
+Crnr Brisbane &amp; Tamar Streets  
+  
+**When**  
+Saturday 26th November  
+2:00pm Start  
+As usual, people are welcome to join for lunch downstairs at 1:00pm  
+Hope to see you there!  
+  
+Note that there will be no December meeting in Launceston.

--- a/_posts/2017-01-24-launceston-january-meeting-28th-january-porting-games-to-linux-royal-oak.md
+++ b/_posts/2017-01-24-launceston-january-meeting-28th-january-porting-games-to-linux-royal-oak.md
@@ -1,0 +1,21 @@
+---
+layout: post
+title: "Launceston January Meeting: 28th January - Porting Games To Linux (Royal Oak)"
+date: 2017-01-24 14:51 +1100
+categories: launceston
+---
+
+Hi people! For this month's Launceston meeting, Cheese will be giving a repeat
+of his recent linux.conf.au talk on porting games to Linux and the impact that
+can have on Free Software ecosystems.  
+  
+**Where**  
+Upstairs meeting room  
+Royal Oak  
+Crnr Brisbane &amp; Tamar Streets  
+  
+**When**  
+Saturday 28th January  
+2:00pm Start  
+As usual, people are welcome to join for lunch downstairs at 1:00pm  
+Hope to see you there!

--- a/_posts/2017-02-08-launceston-february-meeting-25th-feb-project-management-with-f-oss-enterprize.md
+++ b/_posts/2017-02-08-launceston-february-meeting-25th-feb-project-management-with-f-oss-enterprize.md
@@ -1,0 +1,26 @@
+---
+layout: post
+title: "Launceston February Meeting: 25th Feb - Project Management with F/OSS (Enterprize)"
+date: 2017-02-08 21:04 +1100
+categories: launceston
+---
+
+Hi people! For this month's Launceston meeting, we'll be taking a look at
+using ProjectLibre, Task Coach and Freeplane in project management contexts.  
+Please note the **change in venue**. After 9 years, TasLUG's Launceston
+meetings will be relocating from the Royal Oak to Enterprize on Patterson
+Street, which will give us access to a larger, more accommodating space. To
+celebrate, we'll be opening the meeting with a 20 minute recap of TasLUG
+history - a great introduction for newcomers and a chance to reminisce for
+long-time attendees.  
+  
+**Where**  
+Enterprize  
+22-24 Patterson St  
+  
+**When**  
+Saturday 25th February  
+2:00pm Start  
+  
+As always, everybody is welcome to come along and join the discussion. Hope to
+see you there!

--- a/_posts/2017-02-13-hobart-meeting-16th-february-new-place-amp-lca-inspired-lightning-talks.md
+++ b/_posts/2017-02-13-hobart-meeting-16th-february-new-place-amp-lca-inspired-lightning-talks.md
@@ -1,0 +1,42 @@
+---
+layout: post
+title: "Hobart Meeting 16th February - New Place &amp; LCA Inspired Lightning Talks"
+date: 2017-02-13 13:26 +1100
+categories: hobart
+---
+
+Sorry for the late notice for this month's meething, but it's been a busy time
+at work and some delays nailing down a new venue.  
+  
+This month we will be meeting at Kickstart Arts in Newtown. We have one of
+their rooms made available to us with the new Hobart Makers Inc which is
+itself is something to talk about.  
+  
+There is no set speaker for this month. Those of us who went to linux.conf.au
+in January are now super inspired to (continue) to work on open source
+projects, and I'd like to invite you to come along and give a 5 minute talk
+about what you thought was great and what your plans for making open source
+things are for 2017. We'll get in some Pizza from Pizzarazzi and there will be
+tea and coffee available but you can also bring along a refreshment.  
+  
+When: Open at 6pm for 6:30pm start/pizza order Thursday 16th February 2017  
+  
+Where: Kickstart Arts - Hobart Makers Inc space, Admin building, St Johns
+Avennue Newtown  
+  
+Agenda:  
+  
+
+  * 6pm arrive and chat
+  * 6.30pm - Order Pizza, Talk about the new space, lightning talks, plan for 2017.
+
+How to get there:  
+  
+Kickstart Arts is in St Johns Avenue New Town. Here is an Open Street Map
+link: <https://umap.openstreetmap.fr/en/map/taslug-february-
+map_126713#18/-42.85452/147.29794>  
+  
+Here is a streetview that should help
+[https://taslug.org.au/url/214817](https://s3.tidyhq.com/orgs/58897abefe25/storage/87ac088f261d77da26d196e3dbeb85f9badbac8c/original/HobartMakersEntrance.png?1486942211
+"https://s3.tidyhq.com/orgs/58897abefe25/storage/87ac088f261d77da26d196e3dbeb85f9badbac8c/original/HobartMakersEntrance.png?1486942211"
+)

--- a/_posts/2017-03-20-launceston-march-meeting-25th-march-illustrating-with-inkscape-0-92-enterprize.md
+++ b/_posts/2017-03-20-launceston-march-meeting-25th-march-illustrating-with-inkscape-0-92-enterprize.md
@@ -1,0 +1,24 @@
+---
+layout: post
+title: "Launceston March Meeting: 25th March - Illustrating With Inkscape 0.92 (Enterprize)"
+date: 2017-03-20 11:11 +1100
+categories: launceston
+---
+
+Hi people! For this month's Launceston meeting, we'll be taking a look at some
+of the new features in Inkscape 0.92 and going through the process of
+illustrating a picture.  
+Please note the **new venue**. TasLUG's Launceston meetings are now heled at
+Enterprize on Patterson Street. Big thanks to the Royal Oak for hosting us for
+9 years!  
+  
+**Where**  
+Enterprize  
+22-24 Patterson St  
+  
+**When**  
+Saturday 25th March  
+2:00pm Start  
+  
+As always, everybody is welcome to come along and join the discussion. Hope to
+see you there!

--- a/_posts/2017-04-21-launceston-april-meeting-29th-april-painting-with-krita-enterprize.md
+++ b/_posts/2017-04-21-launceston-april-meeting-29th-april-painting-with-krita-enterprize.md
@@ -1,0 +1,23 @@
+---
+layout: post
+title: "Launceston April Meeting: 29th April - Painting With Krita (Enterprize)"
+date: 2017-04-21 16:51 +1000
+categories: launceston
+---
+
+Hi people! For this month's Launceston meeting, we'll be taking a look at some
+of the new features in recent Krita releases.  
+Please note the **new venue**. TasLUG's Launceston meetings are now heled at
+Enterprize on Patterson Street. Big thanks to the Royal Oak for hosting us for
+9 years!  
+  
+**Where**  
+Enterprize  
+22-24 Patterson St  
+  
+**When**  
+Saturday 29th April  
+2:00pm Start  
+  
+As always, everybody is welcome to come along and join the discussion. Hope to
+see you there!

--- a/_posts/2017-05-12-hobart-may-18th-meeting-taking-the-lede-on-domestic-routers.md
+++ b/_posts/2017-05-12-hobart-may-18th-meeting-taking-the-lede-on-domestic-routers.md
@@ -1,0 +1,53 @@
+---
+layout: post
+title: "Hobart May 18th Meeting - Taking the LEDE on Domestic Routers"
+date: 2017-05-12 21:41 +1000
+categories: hobart
+---
+
+Hi LUGers!  
+  
+This month we will be meeting at Kickstart Arts in Newtown again. Check the
+signage out front as to which room we are in.  
+  
+This month we have our venerable TasLUG member Peter Lawler speaking LEDE
+which is an active fork of OpenWRT. With many of us thinking of an upgrade to
+our home routers to take advantage of higher speed WiFi and broadband, there's
+no better time to put some open source on your gateway to the Interwebs. There
+is also be some time for a lightning talk or two if you have something you
+want to discuss or demo.  
+  
+We'll get in some Pizza from Pizzarazzi and there will be tea and coffee
+available but you can also bring along a refreshment.  
+  
+_When_: Open at 6pm for 6:30pm start/pizza order Thursday 18th May 2017  
+  
+_Where_: Kickstart Arts - Hobart Makers Inc space, St Johns Avennue Newtown  
+  
+_Agenda_:  
+  
+
+  * 6pm arrive and chat
+  * 6.30pm - We'll put in a Pizza order, lightning talks and demos.
+  * 7pm - Talk - Taking the LEDE on domestic routers - Peter Lawler
+
+LEDE is a very active fork of OpenWRT, a free software for routers. In his
+talk, Peter will introduce you to LEDE on domestic routers and walk you
+through the steps of setting it up including implementing OpenVPN and
+utilising USB sticks to expand capabilities.  
+  
+
+  * 8pm finish up
+
+_How to get there:_  
+  
+Kickstart Arts is in St Johns Avenue New Town. Here is an Open Street Map
+link: <https://umap.openstreetmap.fr/en/map/taslug-february-
+map_126713#18/-42.85452/147.29794>  
+  
+_Coming up:_  
+  
+May 27th - Launceston Road Trip - check out what's happening up north June:
+15th - Hobart Meeting - LUG Pub. Probably Shambles July - Introduction to
+MicroPython August - LoRa IoT Demonstration Workshop (part of National Science
+Week)

--- a/_posts/2017-05-23-launceston-may-meeting-27th-may-f-oss-for-amateur-radio-and-raspberry-pi-driven-laser-cutters-enterprize.md
+++ b/_posts/2017-05-23-launceston-may-meeting-27th-may-f-oss-for-amateur-radio-and-raspberry-pi-driven-laser-cutters-enterprize.md
@@ -1,0 +1,27 @@
+---
+layout: post
+title: "Launceston May Meeting: 27th May - F/OSS for Amateur Radio and Raspberry Pi Driven Laser Cutters (Enterprize)"
+date: 2017-05-23 15:54 +1000
+categories: launceston
+---
+
+Hi people! For this month's Launceston meeting, we have Scott Bragg from
+Hobart talking about how he merges Linux and open source with amateur radio.
+Over the past months a group in Hobart have been tinkering with a new digital
+transmission mode called FSQ and Scott has been building an automated beacon
+using an Arduino, a clock generator, a RTLSDR dongle and a Raspberry Pi.  
+Additionally, Craig Marshall from Hobart Makers will give a short update of
+efforts to improve their recently acquired laser cutter by replacing the
+control system with a Raspberry Pi, and asking for advice on the next steps to
+get a good open source CAD/CAM workflow.  
+  
+**Where**  
+Enterprize  
+22-24 Patterson St  
+  
+**When**  
+Saturday 27th May  
+2:00pm Start  
+  
+As always, everybody is welcome to come along and join the discussion. Hope to
+see you there!

--- a/scripts/gnusocial_importer.py
+++ b/scripts/gnusocial_importer.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+
+# This script requires the following python packages:
+#   * requests
+#   * dateutils
+#   * html2text
+#   * awesome-slugify
+#
+# It is recommended that you install the packages within a virtualenv and run
+# the script from within the virtualenv:
+#   $ python3 -m venv venv
+#   $ venv/bin/pip install requests dateutils html2text awesome-slugify
+#   $ venv/bin/python scripts/gnusocial_importer.py
+#   $ rm -rf venv
+
+import os
+
+import requests
+from dateutil.parser import parse as date_parse
+from dateutil.tz import gettz
+from html2text import html2text
+from slugify import slugify
+
+URL = 'https://taslug.org.au/api/statuses/user_timeline/2.as'
+TIMEZONE = 'Australia/Hobart'
+OUTPUT = os.path.join(
+    os.path.abspath(os.path.dirname(__file__)),
+    '..',
+    '_posts',
+    '{}')
+
+tzinfo = gettz(TIMEZONE)
+req = requests.get(URL)
+items = req.json().get('items', [])
+
+for item in items:
+    if item.get('verb') != 'post':
+        continue
+
+    published = date_parse(item['published']).astimezone(tzinfo)
+    content = html2text(item['content'])
+
+    if not content.startswith('##'):
+        # Hack for non-conforming post
+        if not content.startswith('Before October'):
+            continue
+        title = ('Hobart October 19th Meeting - ' +
+                 'Brewing Beer with Open Source (Peter Lawler)')
+    else:
+        parts = content.split('\n\n')
+        title = ' '.join(parts[0].strip(' #').split('\n'))
+        content = '\n\n'.join(parts[1:])
+
+    if title.lower().startswith('hobart'):
+        category = 'hobart'
+    elif title.lower().startswith('launceston'):
+        category = 'launceston'
+    elif 'esp8266 hackfest' in title.lower():
+        category = 'hobart'
+    else:
+        category = ''
+
+    filename = '{}-{}.md'.format(published.strftime('%Y-%m-%d'),
+                                 slugify(title, to_lower=True))
+    with open(OUTPUT.format(filename), 'w') as output:
+        output.write("""
+---
+layout: post
+title: "{title}"
+date: {date}
+categories: {category}
+---
+
+{content}""".format(
+            title=title,
+            date=published.strftime('%Y-%m-%d %H:%M %z'),
+            category=category,
+            content=content).strip())


### PR DESCRIPTION
A python script to scape the GNU Social activity stream and generate the equivalent posts in Jekyll. The posts may still need a bit of manual cleanup.

Should close #1